### PR TITLE
Require either insecureSkipVerify or caCertPath

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,10 @@ var (
 		field.WithDisplayName("CA Certificate"),
 	)
 
+	fieldRelationships = []field.SchemaFieldRelationship{
+		field.FieldsAtLeastOneUsed(insecureSkipVerifyField, caCertPathField),
+	}
+
 	ConfigurationFields = []field.SchemaField{
 		addressField,
 		usernameField,
@@ -59,6 +63,7 @@ var (
 //go:generate go run -tags=generate ./gen
 var Config = field.NewConfiguration(
 	ConfigurationFields,
+	field.WithConstraints(fieldRelationships...),
 	field.WithConnectorDisplayName("OpenSearch"),
 	field.WithHelpUrl("/docs/baton/opensearch"),
 	field.WithIconUrl("/static/app-icons/opensearch.svg"),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,15 +15,6 @@ func TestValidateConfig(t *testing.T) {
 		wantErrContains []string
 	}{
 		{
-			name: "valid config",
-			config: &Opensearch{
-				Address:  "http://localhost:9200",
-				Username: "admin",
-				Password: "admin",
-			},
-			wantErr: false,
-		},
-		{
 			name: "invalid config - missing required fields",
 			config: &Opensearch{
 				Address: "http://localhost:9200",
@@ -40,6 +31,26 @@ func TestValidateConfig(t *testing.T) {
 				CaCertPath: "/path/to/ca.pem",
 			},
 			wantErr: false,
+		},
+		{
+			name: "valid config with insecure_skip_verify",
+			config: &Opensearch{
+				Address:            "http://localhost:9200",
+				Username:           "admin",
+				Password:           "admin",
+				InsecureSkipVerify: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid config - neither ca_cert_path nor insecure_skip_verify provided",
+			config: &Opensearch{
+				Address:  "http://localhost:9200",
+				Username: "admin",
+				Password: "admin",
+			},
+			wantErr:         true,
+			wantErrContains: []string{"at least one field was expected", "insecure-skip-verify", "ca-cert-path"},
 		},
 	}
 


### PR DESCRIPTION
#### Description
This PR requires that either `insecureSkipVerify` or `caCertPath` is populated. 

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
