### PR TITLE
Add insecure verify to capabitilies workflow

### DIFF
--- a/.github/workflows/capabilities_and_config.yaml
+++ b/.github/workflows/capabilities_and_config.yaml
@@ -28,7 +28,7 @@ jobs:
         run: ./connector config > config_schema.json
 
       - name: Run and save capabilities output
-        run: ./connector --address="https://example.com" --username="admin" --password="example" capabilities > baton_capabilities.json
+        run: ./connector --address="https://example.com" --username="admin" --password="example" --insecure-skip-verify=true capabilities > baton_capabilities.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
#### Description

- This pr adds `insecure-skip-verify` to the capabilities workflow. This is needed since I recently added a constraint requiring either this or `ca-cert-path`.




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
