### PR TITLE
perf: set explicit Timeout on the opensearch *http.Client

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
@@ -84,6 +85,7 @@ func NewClient(ctx context.Context, address string, username, password, userMatc
 	}
 
 	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},


### PR DESCRIPTION
\`NewClient\` constructs an \`*http.Client\` literal with a custom \`Transport\` (for TLS) but no \`Timeout\`. \`uhttp.NewBaseHttpClientWithContext\` wraps the client with transport-level timeouts (TLSHandshakeTimeout, ResponseHeaderTimeout) but does not set the overall request \`Timeout\`. Without the per-request bound, a slow/hung OpenSearch endpoint keeps the goroutine alive past every transport-level deadline.

Added a 30s \`Timeout\` matching the baton-sdk \`uhttp\` transport defaults.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`http_client_literal_without_timeout\`.